### PR TITLE
fixing panic on unwrap

### DIFF
--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,5 +1,5 @@
 pub fn trim_nul_terminated_string<S: Into<String>>(s: S) -> String {
     let s = s.into();
-    let end_index = s.find('\0').unwrap();
+    let end_index = s.find('\0').unwrap_or(0);
     s[..end_index].to_string()
 }


### PR DESCRIPTION
supplying a default value of 0 if the unwrap fails to prevent panics in the trim_nul_terminated_string function in strings.rs